### PR TITLE
Add game summary and integrate into prompts

### DIFF
--- a/dune.json
+++ b/dune.json
@@ -1,4 +1,5 @@
 {
+  "game_summary": "In this survival sandbox game set on Arrakis, players explore the desert, harvest spice, craft gear and vehicles, build shelters, manage water, and face hostile forces. The goal is to survive, expand your base, and thrive amid sandstorms, rival factions, and monstrous sandworms.",
   "item_list": [
     "A Dart for Every Man",
     "Abulurd's Rapture",

--- a/message_handler.py
+++ b/message_handler.py
@@ -18,6 +18,7 @@ class MessageHandler:
         self.bot = bot
         self.game_data = self.load_game_data("dune.json")
         self.item_lookup = {name.lower(): details for name, details in self.game_data.get("item_dictionary", {}).items()}
+        self.game_summary = self.game_data.get("game_summary", "")
 
     async def handle_message(self, message):
         channel_id = str(message.channel.id)
@@ -38,6 +39,8 @@ class MessageHandler:
             if msg["content"].strip():
                 role = "assistant" if msg["role"] == "ai" else msg["role"]
                 messages.append({"role": role, "content": msg["content"]})
+        if self.game_summary:
+            messages.append({"role": "system", "content": f"Game summary:\n{self.game_summary}"})
         game_info = self.get_relevant_game_info(user_message)
         if game_info:
             messages.append({"role": "system", "content": f"Game data:\n{game_info}"})
@@ -165,3 +168,4 @@ class MessageHandler:
 
         if content.strip():
             self.memory_manager.add_ai_message(str(message.channel.id), guild_id, user_id, content)
+


### PR DESCRIPTION
## Summary
- Add overall game summary to `dune.json`
- Include game summary in system messages so bot uses JSON context

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from message_handler import MessageHandler
handler = MessageHandler()
print('Summary:', handler.game_summary)
print(handler.get_relevant_game_info('Stillsuits'))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68a99d405178832990c774fefefc88d6