### PR TITLE
Switch bot to OpenAI large model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Dune-Discord-Bot
-Dune info Bot for Discord using the Unity model and in-game data from `dune.json`.
+Dune info Bot for Discord using the `openai-large` model and in-game data from `dune.json`.

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,6 +1,6 @@
-WHAT IS UNITY?
---------------
-Unity is an AI Discord bot that chats, remembers, and generates images/code. Uses Pollinations.ai API, switches models, and saves convos.
+WHAT IS DUNE BOT?
+-----------------
+Dune Bot is an AI Discord bot that chats, remembers, and generates images/code. Uses Pollinations.ai API, switches models, and saves convos. Default model is `openai-large`.
 
 KEY FEATURES
 ------------
@@ -57,7 +57,7 @@ SETUP
 
 COMMANDS
 --------
-- !unityhelp - Show commands/models
+- !bothelp - Show commands/models
 - !setmodel - Pick AI model (DM)
 - !savememory <text> - Save channel note
 - !wipe - Clear chat history
@@ -72,7 +72,7 @@ HOW IT WORKS
 ------------
 - MEMORY: Last 20 messages/user/model, 5 channel notes, saved in chat_data.json
 - IMAGES: Detects "image"/"draw", uses Pollinations.ai
-- MODELS: User-picked, defaults to "unity"
+- MODELS: User-picked, defaults to "openai-large"
 - TEXT: <2000 chars = message, 2000-4096 chars = embed, >4096 chars = .txt file
 
 FILES
@@ -116,4 +116,4 @@ WHY UNITY?
 - Adapts to users
 - Fits any server
 
-Check logs or restart if stuck. More chats = better Unity!
+Check logs or restart if stuck. More chats = better results!

--- a/api_client.py
+++ b/api_client.py
@@ -58,7 +58,8 @@ class APIClient:
                 return [{"name": m.strip()} for m in result]
             if all(isinstance(m, dict) and "name" in m for m in result):
                 return [{"name": m["name"].strip(), "description": m.get("description", "")} for m in result]
-        return [{"name": "unity", "description": "Default unity model"}]
+        # Fallback to the OpenAI large model if the models endpoint is unavailable
+        return [{"name": "openai-large", "description": "Default OpenAI large model"}]
 
     async def send_message(self, messages: list, model: str | None):
         if self.session is None or self.session.closed:

--- a/bot.py
+++ b/bot.py
@@ -34,12 +34,21 @@ bot.memory_manager = memory_manager
 
 async def setup_bot():
     await bot.wait_until_ready()
-    models = [{"name": "unity", "description": "Default unity model"}]
+    # Fetch available models from the Pollinations API
+    models = await api_client.fetch_models()
     memory_manager.set_models(models)
-    config.default_model = "unity"
+    # Prefer the OpenAI large model when available
+    openai_large = next(
+        (m["name"] for m in models if "openai" in m["name"].lower() and "large" in m["name"].lower()),
+        None,
+    )
+    if openai_large:
+        config.default_model = openai_large
+    elif models:
+        config.default_model = models[0]["name"]
     data_manager.load_data(memory_manager)
     setup_commands(bot)
-    print("Loaded unity model")
+    print(f"Loaded {config.default_model} model")
 
 @bot.event
 async def on_ready():

--- a/commands.py
+++ b/commands.py
@@ -3,25 +3,25 @@ from discord.ext import commands
 
 
 def setup_commands(bot):
-    @bot.command(name="unityhelp")
-    async def unityhelp(ctx):
+    @bot.command(name="bothelp")
+    async def bothelp(ctx):
         embed = discord.Embed(
-            title="Unity Bot Help",
+            title="Dune Bot Help",
             description="Available commands:",
             color=0x00ff00,
             timestamp=discord.utils.utcnow()
         )
         embed.add_field(
             name="Commands",
-            value="`!unityhelp` - Show this help\n`!savememory <text>` - Save a memory\n`!wipe` - Clear chat history",
+            value="`!bothelp` - Show this help\n`!savememory <text>` - Save a memory\n`!wipe` - Clear chat history",
             inline=False
         )
         embed.add_field(
             name="Model",
-            value="Unity (default)",
+            value=f"{bot.memory_manager.api_client.config.default_model} (default)",
             inline=False
         )
-        embed.set_footer(text="Unity | Pollinations.ai")
+        embed.set_footer(text="Pollinations.ai")
         await ctx.send(embed=embed)
 
     @bot.command(name="savememory")

--- a/config.py
+++ b/config.py
@@ -43,7 +43,8 @@ class Config:
         logger.info(f"Successfully loaded pollinations token: {self.pollinations_token[:10]}... (truncated for security)")
 
         # Bot configuration
-        self.default_model = "unity"
+        # Default to the OpenAI large model instead of the legacy "unity" model
+        self.default_model = "openai-large"
         try:
             with open("system_instructions.txt", "r") as f:
                 self.system_instructions = f.read().strip()

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -148,7 +148,13 @@ class MemoryManager:
         self.initialize_user(guild_id, user_id)
         model = self.user_models.get(guild_id, {}).get(user_id)
         if model is None:
-            model = "unity"
+            default = (
+                self.api_client.config.default_model
+                if self.api_client and self.api_client.config else "openai-large"
+            )
+            model = default
             self.user_models[guild_id][user_id] = model
-            logger.info(f"Assigned default model {model} for user {user_id} in guild {guild_id}")
+            logger.info(
+                f"Assigned default model {model} for user {user_id} in guild {guild_id}"
+            )
         return model


### PR DESCRIPTION
## Summary
- load models from Pollinations API and prefer `openai-large`
- fall back to `openai-large` if model list unavailable
- rename help command to `!bothelp`
- update docs for new default model

## Testing
- `python -m py_compile config.py api_client.py memory_manager.py bot.py commands.py`
- `curl https://text.pollinations.ai/models` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a9d75374848329aa9aae3186677c1a