### PR TITLE
feat: switch default model to gpt-5-nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Dune-Discord-Bot
-Dune info Bot for Discord using the `openai-large` model and in-game data from `dune.json`.
+Dune info Bot for Discord using the `gpt-5-nano` model and in-game data from `dune.json`.

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,6 +1,6 @@
 WHAT IS DUNE BOT?
 -----------------
-Dune Bot is an AI Discord bot that chats, remembers, and generates images/code. Uses Pollinations.ai API, switches models, and saves convos. Default model is `openai-large`.
+Dune Bot is an AI Discord bot that chats, remembers, and generates images/code. Uses Pollinations.ai API, switches models, and saves convos. Default model is `gpt-5-nano`.
 
 KEY FEATURES
 ------------
@@ -72,7 +72,7 @@ HOW IT WORKS
 ------------
 - MEMORY: Last 20 messages/user/model, 5 channel notes, saved in chat_data.json
 - IMAGES: Detects "image"/"draw", uses Pollinations.ai
-- MODELS: User-picked, defaults to "openai-large"
+- MODELS: User-picked, defaults to "gpt-5-nano"
 - TEXT: <2000 chars = message, 2000-4096 chars = embed, >4096 chars = .txt file
 
 FILES

--- a/api_client.py
+++ b/api_client.py
@@ -58,8 +58,8 @@ class APIClient:
                 return [{"name": m.strip()} for m in result]
             if all(isinstance(m, dict) and "name" in m for m in result):
                 return [{"name": m["name"].strip(), "description": m.get("description", "")} for m in result]
-        # Fallback to the OpenAI large model if the models endpoint is unavailable
-        return [{"name": "openai-large", "description": "Default OpenAI large model"}]
+        # Fallback to the gpt-5-nano model if the models endpoint is unavailable
+        return [{"name": "gpt-5-nano", "description": "Default gpt-5 nano model"}]
 
     async def send_message(self, messages: list, model: str | None):
         if self.session is None or self.session.closed:

--- a/config.py
+++ b/config.py
@@ -43,8 +43,8 @@ class Config:
         logger.info(f"Successfully loaded pollinations token: {self.pollinations_token[:10]}... (truncated for security)")
 
         # Bot configuration
-        # Default to the OpenAI large model instead of the legacy "unity" model
-        self.default_model = "openai-large"
+        # Default to the gpt-5-nano model instead of the legacy "unity" model
+        self.default_model = "gpt-5-nano"
         try:
             with open("system_instructions.txt", "r") as f:
                 self.system_instructions = f.read().strip()

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -150,7 +150,7 @@ class MemoryManager:
         if model is None:
             default = (
                 self.api_client.config.default_model
-                if self.api_client and self.api_client.config else "openai-large"
+                if self.api_client and self.api_client.config else "gpt-5-nano"
             )
             model = default
             self.user_models[guild_id][user_id] = model


### PR DESCRIPTION
## Summary
- default to gpt-5-nano instead of openai-large
- adjust model fallback logic and docs accordingly

## Testing
- `python -m py_compile api_client.py bot.py commands.py config.py data_manager.py memory_manager.py message_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68a9df7cc0d883299c36b8452311ff46