### PR TITLE
Handle gpt-5-nano fixed temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Dune-Discord-Bot
 Dune info Bot for Discord using the `gpt-5-nano` model and in-game data from `dune.json`.
+
+The `gpt-5-nano` model uses a fixed temperature of `0`, so the bot only sends
+the temperature parameter for other models that support it.

--- a/api_client.py
+++ b/api_client.py
@@ -70,10 +70,16 @@ class APIClient:
         payload = {
             "messages": messages,
             "model": model,
-            "temperature": 0.7,
             "max_tokens": 1024,
             "stream": False
         }
+        # The gpt-5-nano model only supports the default temperature of 0.
+        # Including a non-zero temperature value results in an API error.
+        # To maintain compatibility with other models that might support
+        # temperature tuning, only add the temperature field when the
+        # selected model is not gpt-5-nano.
+        if model.lower() != "gpt-5-nano":
+            payload["temperature"] = 0.7
         try:
             result = await self._request_json("POST", self.config.api_url, json=payload, timeout=aiohttp.ClientTimeout(total=30))
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- Avoid sending a non-zero temperature to gpt-5-nano and add safeguards for other models
- Document that gpt-5-nano uses a fixed temperature of 0

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68a9e96a96b08329bf1592a942690129