### PR TITLE
Restrict bot responses to configured channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ SETUP
    - Copy the token (e.g., RG4FePiPdUWkk5CI)
    - Open .env, add: POLLINATIONS_TOKEN=your_token_here
    - Warnings: Never share token publicly, don't commit to Git
-4. Install dependencies:
+4. Optional: Restrict bot to specific channels:
+   - Open .env, add: ALLOWED_CHANNELS=12345,67890
+   - Leave blank to allow all; default is `1408772627538903060`
+5. Install dependencies:
    - Open terminal/command prompt in folder
    - Run: pip install -U pip  (updates pip if needed)
    - Run: pip install -r requirements.txt
    - Run: python -m spacy download en_core_web_sm
-5. Run bot:
+6. Run bot:
    - Double-click RUN_BOT.bat (Windows) or run: python bot.py
 
 COMMANDS

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -47,12 +47,15 @@ SETUP
    - Copy the token (e.g., RG4FePiPdUWkk5CI)
    - Open .env, add: POLLINATIONS_TOKEN=your_token_here
    - Warnings: Never share token publicly, don't commit to Git
-4. Install dependencies:
+4. Optional: Restrict bot to specific channels:
+   - Open .env, add: ALLOWED_CHANNELS=12345,67890
+   - Leave blank to allow all; default is `1408772627538903060`
+5. Install dependencies:
    - Open terminal/command prompt in folder
    - Run: pip install -U pip  (updates pip if needed)
    - Run: pip install -r requirements.txt
    - Run: python -m spacy download en_core_web_sm
-5. Run bot:
+6. Run bot:
    - Double-click RUN_BOT.bat (Windows) or run: python bot.py
 
 COMMANDS

--- a/bot.py
+++ b/bot.py
@@ -55,6 +55,9 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
+    if message.guild and config.allowed_channels and str(message.channel.id) not in config.allowed_channels:
+        return
+
     channel_id = str(message.channel.id)
     guild_id = str(message.guild.id) if message.guild else "DM"
     user_id = str(message.author.id)

--- a/config.py
+++ b/config.py
@@ -53,6 +53,11 @@ class Config:
             raise FileNotFoundError("system_instructions.txt not found")
         self.api_url = f"https://text.pollinations.ai/openai?token={self.pollinations_token}"
         self.models_url = "https://text.pollinations.ai/models"
+        allowed_channels_env = os.getenv("ALLOWED_CHANNELS")
+        if allowed_channels_env:
+            self.allowed_channels = [c.strip() for c in allowed_channels_env.split(",") if c.strip()]
+        else:
+            self.allowed_channels = ["1408772627538903060"]
         self.max_history = 20
         self.max_memories = 5
         self.code_keywords = [


### PR DESCRIPTION
## Summary
- add `ALLOWED_CHANNELS` configuration with default `1408772627538903060`
- limit bot replies to channels listed in config
- document optional channel restriction in README

## Testing
- `python -m py_compile config.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68abf6d3108483298f79df1a6a93a20d