### PR TITLE
Fix channel restriction configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ SETUP
    - Warnings: Never share token publicly, don't commit to Git
 4. Optional: Restrict bot to specific channels:
    - Open .env, add: ALLOWED_CHANNELS=12345,67890
-   - Leave blank to allow all; default is `1408772627538903060`
+     (separate multiple IDs with commas or spaces)
+   - Leave blank or omit to allow the bot in all channels
 5. Install dependencies:
    - Open terminal/command prompt in folder
    - Run: pip install -U pip  (updates pip if needed)

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -49,7 +49,8 @@ SETUP
    - Warnings: Never share token publicly, don't commit to Git
 4. Optional: Restrict bot to specific channels:
    - Open .env, add: ALLOWED_CHANNELS=12345,67890
-   - Leave blank to allow all; default is `1408772627538903060`
+     (separate multiple IDs with commas or spaces)
+   - Leave blank or omit to allow the bot in all channels
 5. Install dependencies:
    - Open terminal/command prompt in folder
    - Run: pip install -U pip  (updates pip if needed)

--- a/config.py
+++ b/config.py
@@ -53,11 +53,19 @@ class Config:
             raise FileNotFoundError("system_instructions.txt not found")
         self.api_url = f"https://text.pollinations.ai/openai?token={self.pollinations_token}"
         self.models_url = "https://text.pollinations.ai/models"
-        allowed_channels_env = os.getenv("ALLOWED_CHANNELS")
+        allowed_channels_env = os.getenv("ALLOWED_CHANNELS", "").strip()
         if allowed_channels_env:
-            self.allowed_channels = [c.strip() for c in allowed_channels_env.split(",") if c.strip()]
+            # Support comma or whitespace separated lists and remove empty entries
+            self.allowed_channels = [
+                c.strip() for c in re.split(r"[\s,]+", allowed_channels_env) if c.strip()
+            ]
         else:
-            self.allowed_channels = ["1408772627538903060"]
+            # Empty list means all channels are allowed
+            self.allowed_channels = []
+        logger.info(
+            "Allowed channels: %s",
+            self.allowed_channels if self.allowed_channels else "all",
+        )
         self.max_history = 20
         self.max_memories = 5
         self.code_keywords = [


### PR DESCRIPTION
## Summary
- allow bot in all channels when `ALLOWED_CHANNELS` env variable is missing or blank
- support comma or whitespace separated channel IDs
- document how to configure channel restrictions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68abface46dc8329bf64741f06b15faa