### PR TITLE
Leverage per-file game data via LLM query planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ FILES
 
 DATA FILES
 ----------
-Game data now lives in the `information/` directory. Each JSON file covers a domain:
+Game data lives in the `information/` directory. Each JSON file covers a domain:
 
 - `items.json` – full item list and details
 - `weapons.json`, `armor.json`, `vehicles.json`, `buildings.json`
 - `skills.json`, `research.json`
 - `tips.json`, `strategies.json`, `gameplay.json`, `volumes.json`
 
-Add or update data by editing the corresponding file or dropping a new `*.json` into `information/`. On startup the bot loads every file in that folder and merges them, so new domains are picked up automatically.
+When a message arrives the bot first asks the LLM which domains it needs, then reads only the named JSON files and sends the relevant entries back with the user's text to craft a final answer. Add or update data by editing the corresponding file or dropping a new `*.json` into `information/`.
 
 TROUBLESHOOTING
 ---------------


### PR DESCRIPTION
## Summary
- Load and index each `information/*.json` file individually instead of merging into a single dataset.
- Ask the LLM which information files and keywords are needed, retrieve matching entries from those files, and include them when generating responses.
- Document the new domain-selection workflow in the README.

## Testing
- `python -m py_compile message_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac1425edc88329a6966a9a3025b2f6