### PR TITLE
Separate persona and data-retrieval instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ FILES
 - requirements.txt - Dependencies
 - .env - Tokens (keep secret)
 - system_instructions.txt - AI rules
+- info_request_instructions.txt - info-query rules
 - RUN_BOT.bat - Start script
 - logs/ - application.log, chat_data.json
 
@@ -108,7 +109,7 @@ Game data lives in the `information/` directory. Each JSON file covers a domain:
 - `skills.json`, `research.json`
 - `tips.json`, `strategies.json`, `gameplay.json`, `volumes.json`
 
-When a message arrives the bot first asks the LLM which domains it needs, then reads only the named JSON files and sends the relevant entries back with the user's text to craft a final answer. Add or update data by editing the corresponding file or dropping a new `*.json` into `information/`.
+When a message arrives the bot first asks the LLM which domains it needs (using `info_request_instructions.txt`), then reads only the named JSON files and sends the relevant entries back with the user's text to craft a final answer. Add or update data by editing the corresponding file or dropping a new `*.json` into `information/`.
 
 TROUBLESHOOTING
 ---------------
@@ -121,6 +122,7 @@ CONFIG TWEAKS
 -------------
 - Edit config.py: max_history (20), max_memories (5), add code/image keywords
 - Edit system_instructions.txt for AI style
+- Edit info_request_instructions.txt for data lookup behavior
 
 SECURITY
 --------

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -91,6 +91,7 @@ FILES
 - requirements.txt - Dependencies
 - .env - Tokens (keep secret)
 - system_instructions.txt - AI rules
+- info_request_instructions.txt - info-query rules
 - RUN_BOT.bat - Start script
 - logs/ - application.log, chat_data.json
 
@@ -105,6 +106,7 @@ CONFIG TWEAKS
 -------------
 - Edit config.py: max_history (20), max_memories (5), add code/image keywords
 - Edit system_instructions.txt for AI style
+- Edit info_request_instructions.txt for data lookup behavior
 
 SECURITY
 --------

--- a/config.py
+++ b/config.py
@@ -51,6 +51,12 @@ class Config:
         except FileNotFoundError:
             logger.error("system_instructions.txt not found")
             raise FileNotFoundError("system_instructions.txt not found")
+        try:
+            with open("info_request_instructions.txt", "r", encoding="utf-8") as f:
+                self.info_request_instructions = f.read().strip()
+        except FileNotFoundError:
+            logger.error("info_request_instructions.txt not found")
+            raise FileNotFoundError("info_request_instructions.txt not found")
         self.api_url = f"https://text.pollinations.ai/openai?token={self.pollinations_token}"
         self.models_url = "https://text.pollinations.ai/models"
         allowed_channels_env = os.getenv("ALLOWED_CHANNELS", "").strip()

--- a/info_request_instructions.txt
+++ b/info_request_instructions.txt
@@ -1,0 +1,7 @@
+You are a query planner for the Dune bot's knowledge base.
+Given a user's message and a list of available information files with short summaries,
+select which files should be retrieved and which search keywords to use.
+Respond only with a JSON object containing two arrays:
+- "files": names of relevant information files in lowercase
+- "keywords": important search terms
+If nothing is relevant, return {"files": [], "keywords": []}.

--- a/message_handler.py
+++ b/message_handler.py
@@ -145,11 +145,7 @@ class MessageHandler:
         - ``keywords``: search terms to locate specific entries.
         """
 
-        sys = (
-            "You are a query planner for a Dune: Awakening knowledge base. "
-            "Return only JSON with keys: files (array of information file names) "
-            "and keywords (array)."
-        )
+        sys = self.config.info_request_instructions
         overview_lines = [f"{name}: {summary}" for name, summary in self.file_summaries.items()]
         overview = "\n".join(overview_lines)
         usr = (


### PR DESCRIPTION
## Summary
- Load new `info_request_instructions.txt` for the LLM query-planning step
- Use file-driven instructions when selecting information JSON files
- Document new instruction file in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68ac225876048329be91a146c4b4a2e4