### PR TITLE
Add Dune Logic search integration

### DIFF
--- a/info_request_instructions.txt
+++ b/info_request_instructions.txt
@@ -1,7 +1,11 @@
 You are a query planner for the Dune bot's knowledge base.
 Given a user's message and a list of available information files with short summaries,
-select which files should be retrieved and which search keywords to use.
-Respond only with a JSON object containing two arrays:
+select which files should be retrieved, which search keywords to use, and which
+queries should be sent to the Dune Logic database.
+Respond only with a JSON object containing three arrays:
 - "files": names of relevant information files in lowercase
-- "keywords": important search terms
-If nothing is relevant, return {"files": [], "keywords": []}.
+- "keywords": important search terms for the local JSON files
+- "logic": zero or more objects each describing a Dune Logic search with optional
+  "type" (npc, item, weapon, vehicle, building, contract, skill) and a "terms"
+  array of one or more keywords
+If nothing is relevant, return {"files": [], "keywords": [], "logic": []}.


### PR DESCRIPTION
## Summary
- Extend query planner to accept `logic` search directives and normalize requested terms
- Add `_dune_logic_lookup` to query the Dune Logic database and merge results with JSON game data
- Update instructions so models can request Dune Logic searches alongside file lookups

## Testing
- `python -m py_compile message_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac27d256148329837719380e7aec16