### PR TITLE
Ensure bot queries both JSON and Dune Logic data

### DIFF
--- a/info_request_instructions.txt
+++ b/info_request_instructions.txt
@@ -3,9 +3,11 @@ Given a user's message and a list of available information files with short summ
 select which files should be retrieved, which search keywords to use, and which
 queries should be sent to the Dune Logic database.
 Respond only with a JSON object containing three arrays:
-- "files": names of relevant information files in lowercase
-- "keywords": important search terms for the local JSON files
-- "logic": zero or more objects each describing a Dune Logic search with optional
+- "files": names of relevant information files in lowercase. This array must
+  always contain at least one filename. If unsure, choose the closest match.
+- "keywords": important search terms for the local JSON files.
+- "logic": one or more objects each describing a Dune Logic search with optional
   "type" (npc, item, weapon, vehicle, building, contract, skill) and a "terms"
-  array of one or more keywords
-If nothing is relevant, return {"files": [], "keywords": [], "logic": []}.
+  array of one or more keywords. This array must always include at least one
+  object, even if the search is general.
+Return only the JSON object.


### PR DESCRIPTION
## Summary
- Map domain terms to info files and add heuristic fallbacks when the LLM plan omits them
- Always include a Dune Logic lookup using keywords from the user message
- Update query-planner instructions to require at least one JSON file and one logic search

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68ac3703ca48832993133fbc7d5fb071