### PR TITLE
Add cachetools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ DEPENDENCIES
 - googletrans==4.0.0-rc1
 - aiofiles
 - python-dotenv
+- cachetools
 
 SETUP
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ langdetect
 googletrans==4.0.0-rc1
 aiofiles
 python-dotenv
+cachetools


### PR DESCRIPTION
## Summary
- add cachetools to requirements
- update README dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement cachetools)*
- `python -m py_compile dune_logic/api.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac443dfdc48329850266cf8e246105