### PR TITLE
Handle Pollinations image URLs

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -4,6 +4,7 @@ import json
 import logging
 from io import BytesIO
 import aiohttp
+import re
 
 from dune_logic import search as dune_search
 
@@ -66,6 +67,8 @@ def setup_commands(bot):
                         if resp.status == 200:
                             data = await resp.read()
                             filename = url.split("/")[-1].split("?")[0] or "image.png"
+                            if not re.search(r"\.(png|jpg|jpeg|gif|webp)$", filename, re.IGNORECASE):
+                                filename += ".png"
                             files.append(discord.File(BytesIO(data), filename=filename))
             except Exception as e:
                 logger.warning(f"Failed to fetch image {url}: {e}")


### PR DESCRIPTION
## Summary
- detect Pollinations links and treat as images
- default missing file extensions to .png when uploading

## Testing
- `python -m py_compile commands.py message_handler.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_b_68ad5e6db18c83298aa94efe6a2f2453