### PR TITLE
Delay responses to messages from other bots

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -61,6 +61,10 @@ async def on_message(message):
     if message.guild and config.allowed_channels and str(message.channel.id) not in config.allowed_channels:
         return
 
+    # If another bot sends a message in an allowed channel, wait before responding
+    if message.author.bot:
+        await asyncio.sleep(10)
+
     channel_id = str(message.channel.id)
     guild_id = str(message.guild.id) if message.guild else "DM"
     user_id = str(message.author.id)


### PR DESCRIPTION
## Summary
- ensure the Discord bot ignores its own messages and waits 10 seconds before answering other bots

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b584c1f6c4832996c66de418183ec8